### PR TITLE
Add configuration via config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,4 @@ RUN npm run build
 FROM nginx:stable-alpine
 COPY nginx/ /etc/nginx/
 COPY --from=builder /usr/src/app/build /usr/share/nginx/html
+COPY config/ /etc/wallablock/

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+config.json

--- a/config/default.json
+++ b/config/default.json
@@ -1,0 +1,8 @@
+{
+  "blockchainUrl": null,
+  "fileproxyUrl": null,
+  "elastic": {
+    "url": null,
+    "key": null
+  }
+}

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -6,13 +6,18 @@ server {
 
     location / {
         index  index.html index.htm;
-        try_files $uri $uri/ /index.html =500;
+        try_files $uri $uri/ =500 /index.html =500;
+    }
+
+    location = /config.json {
+        root /etc/wallablock;
+        try_files /config.json /default.json =404;
     }
 
     location /static {
         expires 7d;
         access_log off;
-        
+
         location ~* \.(?:svgz?|ttf|ttc|otf|eot|woff2?)$ {
             add_header Access-Control-Allow-Origin "*";
         }

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -6,7 +6,7 @@ server {
 
     location / {
         index  index.html index.htm;
-        try_files $uri $uri/ =500 /index.html =500;
+        try_files $uri $uri/ /index.html =500;
     }
 
     location = /config.json {


### PR DESCRIPTION
Allow configuration via a JSON file on the server (`/etc/wallablock/config.json`; `default.json` for defaults).

Only server-side implementation.